### PR TITLE
Fix image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,50 +4,50 @@ I develop software, play :guitar: &amp; :musical_keyboard: and film with a drone
 
 ## My stack highlights
 
-<a href="https://php.net/" title="PHP"><img src="https://github.com/get-icon/geticon/blob/master/logos/php.svg" alt="PHP" width="21px" height="21px"></a>
-<a href="https://laravel.com/" title="Laravel"><img src="https://github.com/get-icon/geticon/blob/master/logos/laravel.svg" alt="Laravel" width="21px" height="21px"></a>
-<a href="https://lumen.laravel.com/" title="Lumen"><img src="https://github.com/get-icon/geticon/blob/master/logos/lumen.svg" alt="Lumen" width="21px" height="21px"></a>
-<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" title="JavaScript"><img src="https://github.com/get-icon/geticon/blob/master/logos/javascript.svg" alt="JavaScript" width="21px" height="21px"></a>
-<a href="https://www.nginx.com/" title="NGINX"><img src="https://github.com/get-icon/geticon/blob/master/logos/nginx.svg" alt="NGINX" width="21px" height="21px"></a>
-<a href="https://www.w3.org/TR/html5/" title="HTML5"><img src="https://github.com/get-icon/geticon/blob/master/logos/html-5.svg" alt="HTML5" width="21px" height="21px"></a>
-<a href="https://redis.io/" title="Redis"><img src="https://github.com/get-icon/geticon/blob/master/logos/redis.svg" alt="Redis" width="21px" height="21px"></a>
-<a href="https://dev.mysql.com/" title="MySQL"><img src="https://github.com/get-icon/geticon/blob/master/logos/mysql.svg" alt="MySQL" width="21px" height="21px"></a>
-<a href="https://mariadb.org/" title="MariaDB"><img src="https://github.com/get-icon/geticon/blob/master/logos/mariadb-icon.svg" alt="MariaDB" width="21px" height="21px"></a>
-<a href="https://www.docker.com/" title="docker"><img src="https://github.com/get-icon/geticon/blob/master/logos/docker-icon.svg" alt="docker" width="21px" height="21px"></a>
-<a href="https://git-scm.com/" title="Git"><img src="https://github.com/get-icon/geticon/blob/master/logos/git-icon.svg" alt="Git" width="21px" height="21px"></a>
-<a href="https://github.com/" title="Github"><img src="https://github.com/get-icon/geticon/blob/master/logos/github-icon.svg" alt="Github" width="21px" height="21px"></a>
-<a href="https://about.gitlab.com/" title="Gitlab"><img src="https://github.com/get-icon/geticon/blob/master/logos/gitlab.svg" alt="Gitlab" width="21px" height="21px"></a>
-<a href="https://bitbucket.org/" title="Bitbucket"><img src="https://github.com/get-icon/geticon/blob/master/logos/bitbucket.svg" alt="Bitbucket" width="21px" height="21px"></a>
-<a href="https://getsentry.com/welcome/" title="Sentry"><img src="https://github.com/get-icon/geticon/blob/master/logos/sentry.svg" alt="Sentry" width="21px" height="21px"></a>
-<a href="https://www.gnu.org/software/bash/" title="Bash"><img src="https://github.com/get-icon/geticon/blob/master/logos/bash.svg" alt="Bash" width="21px" height="21px"></a>
-<a href="https://www.tensorflow.org/" title="TensorFlow"><img src="https://github.com/get-icon/geticon/blob/master/logos/tensorflow.svg" alt="TensorFlow" width="21px" height="21px"></a>
-<a href="https://www.w3.org/2001/sw/wiki/REST" title="Rest"><img src="https://github.com/get-icon/geticon/blob/master/logos/rest.svg" alt="Rest" width="21px" height="21px"></a>
-<a href="https://www.digitalocean.com/" title="DigitalOcean"><img src="https://github.com/get-icon/geticon/blob/master/logos/digital-ocean.svg" alt="DigitalOcean" width="21px" height="21px"></a>
-<a href="https://www.cloudflare.com/" title="CloudFlare"><img src="https://github.com/get-icon/geticon/blob/master/logos/cloudflare.svg" alt="CloudFlare" width="21px" height="21px"></a>
-<a href="https://mailchimp.com/" title="Mailchimp"><img src="https://github.com/get-icon/geticon/blob/master/logos/mailchimp-freddie.svg" alt="Mailchimp" width="21px" height="21px"></a>
-<a href="https://trello.com/" title="Trello"><img src="https://github.com/get-icon/geticon/blob/master/logos/trello.svg" alt="Trello" width="21px" height="21px"></a>
-<a href="https://www.ubuntu.com/" title="ubuntu"><img src="https://github.com/get-icon/geticon/blob/master/logos/ubuntu.svg" alt="ubuntu" width="21px" height="21px"></a>
-<a href="https://www.debian.org/" title="debian"><img src="https://github.com/get-icon/geticon/blob/master/logos/debian.svg" alt="debian" width="21px" height="21px"></a>
-<a href="https://www.centos.org/" title="CentOS"><img src="https://github.com/get-icon/geticon/blob/master/logos/centos-icon.svg" alt="CentOS" width="21px" height="21px"></a>
-<a href="https://www.google.com/drive/" title="Google Drive"><img src="https://github.com/get-icon/geticon/blob/master/logos/google-drive.svg" alt="Google Drive" width="21px" height="21px"></a>
-<a href="https://tc39.es/ecma262/" title="ECMAScript 6"><img src="https://github.com/get-icon/geticon/blob/master/logos/es6.svg" alt="ECMAScript 6" width="21px" height="21px"></a>
-<a href="https://vuejs.org/" title="Vue.js"><img src="https://github.com/get-icon/geticon/blob/master/logos/vue.svg" alt="Vue.js" width="21px" height="21px"></a>
-<a href="https://jquery.com/" title="jQuery"><img src="https://github.com/get-icon/geticon/blob/master/logos/jquery-icon.svg" alt="jQuery" width="21px" height="21px"></a>
-<a href="https://www.w3.org/TR/CSS/" title="CSS3"><img src="https://github.com/get-icon/geticon/blob/master/logos/css-3.svg" alt="CSS3" width="21px" height="21px"></a>
-<a href="https://getbootstrap.com/" title="Bootstrap"><img src="https://github.com/get-icon/geticon/blob/master/logos/bootstrap.svg" alt="Bootstrap" width="21px" height="21px"></a>
-<a href="https://www.w3.org/TR/html5/" title="HTML5"><img src="https://github.com/get-icon/geticon/blob/master/logos/html-5.svg" alt="HTML5" width="21px" height="21px"></a>
-<a href="https://nodejs.org/" title="Node.js"><img src="https://github.com/get-icon/geticon/blob/master/logos/nodejs-icon.svg" alt="Node.js" width="21px" height="21px"></a>
-<a href="https://www.python.org/" title="Python"><img src="https://github.com/get-icon/geticon/blob/master/logos/python.svg" alt="Python" width="21px" height="21px"></a>
-<a href="https://www.npmjs.com/" title="npm"><img src="https://github.com/get-icon/geticon/blob/master/logos/npm.svg" alt="npm" width="21px" height="21px"></a>
-<a href="https://webpack.js.org/" title="webpack"><img src="https://github.com/get-icon/geticon/blob/master/logos/webpack.svg" alt="webpack" width="21px" height="21px"></a>
-<a href="https://babeljs.io/" title="Babel"><img src="https://github.com/get-icon/geticon/blob/master/logos/babel.svg" alt="Babel" width="21px" height="21px"></a>
-<a href="https://code.visualstudio.com/" title="Visual Studio Code"><img src="https://github.com/get-icon/geticon/blob/master/logos/visual-studio-code.svg" alt="Visual Studio Code" width="21px" height="21px"></a>
-<a href="https://electron.atom.io/" title="Electron"><img src="https://github.com/get-icon/geticon/blob/master/logos/electron.svg" alt="Electron" width="21px" height="21px"></a>
-<a href="https://wordpress.org/" title="WordPress"><img src="https://github.com/get-icon/geticon/blob/master/logos/wordpress-icon.svg" alt="WordPress" width="21px" height="21px"></a>
-<a href="https://material-ui.com/" title="Material UI"><img src="https://github.com/get-icon/geticon/blob/master/logos/material-ui.svg" alt="Material UI" width="21px" height="21px"></a>
-<a href="https://www.yiiframework.com/" title="Yii"><img src="https://github.com/get-icon/geticon/blob/master/logos/yii.svg" alt="Yii" width="21px" height="21px"></a>
-<a href="https://www.adobe.com/products/photoshop.html" title="Adobe Photoshop"><img src="https://github.com/get-icon/geticon/blob/master/logos/adobe-photoshop.svg" alt="Adobe Photoshop" width="21px" height="21px"></a>
-<a href="https://www.adobe.com/products/illustrator.html" title="Adobe Illustrator"><img src="https://github.com/get-icon/geticon/blob/master/logos/adobe-illustrator.svg" alt="Adobe Illustrator" width="21px" height="21px"></a>
+<a href="https://php.net/" title="PHP"><img src="https://github.com/get-icon/geticon/raw/master/icons/php.svg" alt="PHP" width="21px" height="21px"></a>
+<a href="https://laravel.com/" title="Laravel"><img src="https://github.com/get-icon/geticon/raw/master/icons/laravel.svg" alt="Laravel" width="21px" height="21px"></a>
+<a href="https://lumen.laravel.com/" title="Lumen"><img src="https://github.com/get-icon/geticon/raw/master/icons/lumen.svg" alt="Lumen" width="21px" height="21px"></a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" title="JavaScript"><img src="https://github.com/get-icon/geticon/raw/master/icons/javascript.svg" alt="JavaScript" width="21px" height="21px"></a>
+<a href="https://www.nginx.com/" title="NGINX"><img src="https://github.com/get-icon/geticon/raw/master/icons/nginx.svg" alt="NGINX" width="21px" height="21px"></a>
+<a href="https://www.w3.org/TR/html5/" title="HTML5"><img src="https://github.com/get-icon/geticon/raw/master/icons/html-5.svg" alt="HTML5" width="21px" height="21px"></a>
+<a href="https://redis.io/" title="Redis"><img src="https://github.com/get-icon/geticon/raw/master/icons/redis.svg" alt="Redis" width="21px" height="21px"></a>
+<a href="https://dev.mysql.com/" title="MySQL"><img src="https://github.com/get-icon/geticon/raw/master/icons/mysql.svg" alt="MySQL" width="21px" height="21px"></a>
+<a href="https://mariadb.org/" title="MariaDB"><img src="https://github.com/get-icon/geticon/raw/master/icons/mariadb-icon.svg" alt="MariaDB" width="21px" height="21px"></a>
+<a href="https://www.docker.com/" title="docker"><img src="https://github.com/get-icon/geticon/raw/master/icons/docker-icon.svg" alt="docker" width="21px" height="21px"></a>
+<a href="https://git-scm.com/" title="Git"><img src="https://github.com/get-icon/geticon/raw/master/icons/git-icon.svg" alt="Git" width="21px" height="21px"></a>
+<a href="https://github.com/" title="Github"><img src="https://github.com/get-icon/geticon/raw/master/icons/github-icon.svg" alt="Github" width="21px" height="21px"></a>
+<a href="https://about.gitlab.com/" title="Gitlab"><img src="https://github.com/get-icon/geticon/raw/master/icons/gitlab.svg" alt="Gitlab" width="21px" height="21px"></a>
+<a href="https://bitbucket.org/" title="Bitbucket"><img src="https://github.com/get-icon/geticon/raw/master/icons/bitbucket.svg" alt="Bitbucket" width="21px" height="21px"></a>
+<a href="https://getsentry.com/welcome/" title="Sentry"><img src="https://github.com/get-icon/geticon/raw/master/icons/sentry.svg" alt="Sentry" width="21px" height="21px"></a>
+<a href="https://www.gnu.org/software/bash/" title="Bash"><img src="https://github.com/get-icon/geticon/raw/master/icons/bash.svg" alt="Bash" width="21px" height="21px"></a>
+<a href="https://www.tensorflow.org/" title="TensorFlow"><img src="https://github.com/get-icon/geticon/raw/master/icons/tensorflow.svg" alt="TensorFlow" width="21px" height="21px"></a>
+<a href="https://www.w3.org/2001/sw/wiki/REST" title="Rest"><img src="https://github.com/get-icon/geticon/raw/master/icons/rest.svg" alt="Rest" width="21px" height="21px"></a>
+<a href="https://www.digitalocean.com/" title="DigitalOcean"><img src="https://github.com/get-icon/geticon/raw/master/icons/digital-ocean.svg" alt="DigitalOcean" width="21px" height="21px"></a>
+<a href="https://www.cloudflare.com/" title="CloudFlare"><img src="https://github.com/get-icon/geticon/raw/master/icons/cloudflare.svg" alt="CloudFlare" width="21px" height="21px"></a>
+<a href="https://mailchimp.com/" title="Mailchimp"><img src="https://github.com/get-icon/geticon/raw/master/icons/mailchimp-freddie.svg" alt="Mailchimp" width="21px" height="21px"></a>
+<a href="https://trello.com/" title="Trello"><img src="https://github.com/get-icon/geticon/raw/master/icons/trello.svg" alt="Trello" width="21px" height="21px"></a>
+<a href="https://www.ubuntu.com/" title="ubuntu"><img src="https://github.com/get-icon/geticon/raw/master/icons/ubuntu.svg" alt="ubuntu" width="21px" height="21px"></a>
+<a href="https://www.debian.org/" title="debian"><img src="https://github.com/get-icon/geticon/raw/master/icons/debian.svg" alt="debian" width="21px" height="21px"></a>
+<a href="https://www.centos.org/" title="CentOS"><img src="https://github.com/get-icon/geticon/raw/master/icons/centos-icon.svg" alt="CentOS" width="21px" height="21px"></a>
+<a href="https://www.google.com/drive/" title="Google Drive"><img src="https://github.com/get-icon/geticon/raw/master/icons/google-drive.svg" alt="Google Drive" width="21px" height="21px"></a>
+<a href="https://tc39.es/ecma262/" title="ECMAScript 6"><img src="https://github.com/get-icon/geticon/raw/master/icons/es6.svg" alt="ECMAScript 6" width="21px" height="21px"></a>
+<a href="https://vuejs.org/" title="Vue.js"><img src="https://github.com/get-icon/geticon/raw/master/icons/vue.svg" alt="Vue.js" width="21px" height="21px"></a>
+<a href="https://jquery.com/" title="jQuery"><img src="https://github.com/get-icon/geticon/raw/master/icons/jquery-icon.svg" alt="jQuery" width="21px" height="21px"></a>
+<a href="https://www.w3.org/TR/CSS/" title="CSS3"><img src="https://github.com/get-icon/geticon/raw/master/icons/css-3.svg" alt="CSS3" width="21px" height="21px"></a>
+<a href="https://getbootstrap.com/" title="Bootstrap"><img src="https://github.com/get-icon/geticon/raw/master/icons/bootstrap.svg" alt="Bootstrap" width="21px" height="21px"></a>
+<a href="https://www.w3.org/TR/html5/" title="HTML5"><img src="https://github.com/get-icon/geticon/raw/master/icons/html-5.svg" alt="HTML5" width="21px" height="21px"></a>
+<a href="https://nodejs.org/" title="Node.js"><img src="https://github.com/get-icon/geticon/raw/master/icons/nodejs-icon.svg" alt="Node.js" width="21px" height="21px"></a>
+<a href="https://www.python.org/" title="Python"><img src="https://github.com/get-icon/geticon/raw/master/icons/python.svg" alt="Python" width="21px" height="21px"></a>
+<a href="https://www.npmjs.com/" title="npm"><img src="https://github.com/get-icon/geticon/raw/master/icons/npm.svg" alt="npm" width="21px" height="21px"></a>
+<a href="https://webpack.js.org/" title="webpack"><img src="https://github.com/get-icon/geticon/raw/master/icons/webpack.svg" alt="webpack" width="21px" height="21px"></a>
+<a href="https://babeljs.io/" title="Babel"><img src="https://github.com/get-icon/geticon/raw/master/icons/babel.svg" alt="Babel" width="21px" height="21px"></a>
+<a href="https://code.visualstudio.com/" title="Visual Studio Code"><img src="https://github.com/get-icon/geticon/raw/master/icons/visual-studio-code.svg" alt="Visual Studio Code" width="21px" height="21px"></a>
+<a href="https://electron.atom.io/" title="Electron"><img src="https://github.com/get-icon/geticon/raw/master/icons/electron.svg" alt="Electron" width="21px" height="21px"></a>
+<a href="https://wordpress.org/" title="WordPress"><img src="https://github.com/get-icon/geticon/raw/master/icons/wordpress-icon.svg" alt="WordPress" width="21px" height="21px"></a>
+<a href="https://material-ui.com/" title="Material UI"><img src="https://github.com/get-icon/geticon/raw/master/icons/material-ui.svg" alt="Material UI" width="21px" height="21px"></a>
+<a href="https://www.yiiframework.com/" title="Yii"><img src="https://github.com/get-icon/geticon/raw/master/icons/yii.svg" alt="Yii" width="21px" height="21px"></a>
+<a href="https://www.adobe.com/products/photoshop.html" title="Adobe Photoshop"><img src="https://github.com/get-icon/geticon/raw/master/icons/adobe-photoshop.svg" alt="Adobe Photoshop" width="21px" height="21px"></a>
+<a href="https://www.adobe.com/products/illustrator.html" title="Adobe Illustrator"><img src="https://github.com/get-icon/geticon/raw/master/icons/adobe-illustrator.svg" alt="Adobe Illustrator" width="21px" height="21px"></a>
 
 
 For inquiries:


### PR DESCRIPTION
Hi,

[geticon](https://github.com/get-icon/geticon/)'s icon directory is renamed from "logos" to "[icons](https://github.com/get-icon/geticon/tree/master/icons)". I saw you are using the old URLs, it should be updated.

(actually I've never suggested `https://github.com/get-icon/geticon/blob/master/logos/`, it was [`https://github.com/tomchen/stack-icons/blob/master/logos`](https://github.com/tomchen/stack-icons/tree/master/logos), and when I moved the repo to [@get-icon](https://github.com/get-icon/) I didn't change this URL, it links to the archived [tomchen/stack-icons](https://github.com/tomchen/stack-icons/). I've renamed the directory several days ago and have been suggesting `https://github.com/get-icon/geticon/raw/master/icons/` as the image URL base only since then. This URL is permenent. Although in the future I'll probably also use geticon.org (or get-icon.github.io) domain so the images could be cached by github camo)